### PR TITLE
ignore .DS_Store created by MacOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 myjobenv/
 job-website-tutorial.code-workspace
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
可以忽略掉 MacOS 自動產生的 .DS_Store 檔案